### PR TITLE
[codex] Fix Pages deployment links

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -1,10 +1,22 @@
 import { defineConfig } from 'vitepress';
 
+const siteUrl = 'https://markdown-flashcards.tbuser.dev';
+
 // https://vitepress.dev/reference/site-config
 export default defineConfig({
 	title: 'Markdown-Flashcards',
 	description: 'Documentation for the fully local Markdown Flashcards',
-	base: '/markdown-flashcards/docs/',
+	base: '/docs/',
+	head: [
+		[
+			'link',
+			{
+				rel: 'icon',
+				href: '/docs/favicon.svg',
+				type: 'image/svg+xml'
+			}
+		]
+	],
 	themeConfig: {
 		nav: [
 			{
@@ -13,7 +25,7 @@ export default defineConfig({
 			},
 			{
 				text: 'App',
-				link: 'https://tbuserdev.github.io/markdown-flashcards/'
+				link: siteUrl
 			},
 			{
 				text: 'GitHub',

--- a/docs/markdown-flashcards/usage.md
+++ b/docs/markdown-flashcards/usage.md
@@ -9,7 +9,7 @@ There are two ways to get flashcards into the app:
 The easiest way to share or load a deck is by adding a `?preload=` parameter to the app's URL.
 
 Example:
-`https://tbuserdev.github.io/markdown-flashcards/?preload=https://gist.githubusercontent.com/...`
+`https://markdown-flashcards.tbuser.dev/?preload=https://gist.githubusercontent.com/...`
 
 When you open this link, the app will automatically ask if you want to import the deck.
 

--- a/docs/misc/privacy-policy.md
+++ b/docs/misc/privacy-policy.md
@@ -4,7 +4,7 @@
 
 ## 1. Introduction
 
-Welcome to **Markdown-flashcards** ("we," "our," or "us"). We believe that your writing belongs to you. This Privacy Policy explains how we handle your information when you use our application hosted at **[https://tbuserdev.github.io/markdown-flashcards/](https://tbuserdev.github.io/markdown-flashcards/)**.
+Welcome to **Markdown-flashcards** ("we," "our," or "us"). We believe that your writing belongs to you. This Privacy Policy explains how we handle your information when you use our application hosted at **[https://markdown-flashcards.tbuser.dev/](https://markdown-flashcards.tbuser.dev/)**.
 
 Our core philosophy is simple: **We do not want your data.**
 

--- a/docs/misc/terms-of-service.md
+++ b/docs/misc/terms-of-service.md
@@ -4,7 +4,7 @@
 
 ## 1. Acceptance of Terms
 
-By accessing and using **Markdown-Flashcards** (the "Service"), hosted at **https://tbuserdev.github.io/markdown-flashcards/**, you agree to be bound by these Terms of Service. If you do not agree to these terms, please do not use the Service.
+By accessing and using **Markdown-Flashcards** (the "Service"), hosted at **https://markdown-flashcards.tbuser.dev/**, you agree to be bound by these Terms of Service. If you do not agree to these terms, please do not use the Service.
 
 ## 2. The Service & Open Source License
 

--- a/docs/public/favicon.svg
+++ b/docs/public/favicon.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect width="64" height="64" rx="14" fill="#111827" />
+  <path
+    d="M16 18h32v6H16zm0 11h22v6H16zm0 11h32v6H16z"
+    fill="#f9fafb"
+  />
+  <circle cx="45" cy="32" r="5" fill="#22c55e" />
+</svg>

--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
 		<meta charset="UTF-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 		<title>Markdown Flashcards Trainer</title>
+		<link rel="icon" href="./favicon.svg" type="image/svg+xml" />
 		<link rel="preconnect" href="https://fonts.googleapis.com" />
 		<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
 		<link

--- a/public/CNAME
+++ b/public/CNAME
@@ -1,0 +1,1 @@
+markdown-flashcards.tbuser.dev

--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect width="64" height="64" rx="14" fill="#111827" />
+  <path
+    d="M16 18h32v6H16zm0 11h22v6H16zm0 11h32v6H16z"
+    fill="#f9fafb"
+  />
+  <circle cx="45" cy="32" r="5" fill="#22c55e" />
+</svg>

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -658,28 +658,28 @@
 		class="absolute bottom-4 mt-4 flex gap-4 text-center text-xs text-neutral-400 text-neutral-500"
 	>
 		<a
-			href="https://tbuserdev.github.io/markdown-flashcards/docs/"
+			href="https://markdown-flashcards.tbuser.dev/docs/"
 			class="transition-colors hover:text-neutral-300"
 		>
 			Documentation
 		</a>
 		<p>|</p>
 		<a
-			href="https://tbuserdev.github.io/markdown-flashcards/docs/misc/privacy-policy"
+			href="https://markdown-flashcards.tbuser.dev/docs/misc/privacy-policy"
 			class="transition-colors hover:text-neutral-300"
 		>
 			Privacy Policy
 		</a>
 		<p>|</p>
 		<a
-			href="https://tbuserdev.github.io/markdown-flashcards/docs/misc/terms-of-service"
+			href="https://markdown-flashcards.tbuser.dev/docs/misc/terms-of-service"
 			class="transition-colors hover:text-neutral-300"
 		>
 			Terms of Service
 		</a>
 		<p>|</p>
 		<a
-			href="https://tbuserdev.github.io/markdown-flashcards/docs/misc/changelog"
+			href="https://markdown-flashcards.tbuser.dev/docs/misc/changelog"
 			class="transition-colors hover:text-neutral-300"
 		>
 			Changelog

--- a/vite.config.js
+++ b/vite.config.js
@@ -3,6 +3,6 @@ import tailwindcss from '@tailwindcss/vite';
 import { defineConfig } from 'vite';
 
 export default defineConfig({
-	base: '/markdown-flashcards/',
+	base: './',
 	plugins: [tailwindcss(), svelte()]
 });


### PR DESCRIPTION
## Summary
- fix GitHub Pages base paths for app and docs so built assets resolve on custom-domain deployment
- update user-facing docs and footer links to use `https://markdown-flashcards.tbuser.dev`
- add `CNAME` and SVG favicons for app and docs builds

## Root Cause
Pages output still targeted `/markdown-flashcards/` and `/markdown-flashcards/docs/`, but production traffic now resolves through `https://markdown-flashcards.tbuser.dev/`. That left built asset URLs pointing at paths that do not exist on deployed site.

## Impact
- app bundle now loads from custom-domain root without asset 404s
- docs bundle now loads from `/docs/` without broken JS/CSS links
- app footer and docs examples now point at correct live URLs
- Pages artifact now includes `CNAME` and favicon assets

## Validation
- `bun run lint`
- `bun run build`
- `bun run docs:build`
- local smoke test via Playwright against built artifact served from `/` and `/docs/`
